### PR TITLE
Section on starting with msprime diversity

### DIFF
--- a/pyslim_chapter.tex
+++ b/pyslim_chapter.tex
@@ -758,13 +758,14 @@ The example phylogeny we will simulate is encoded in the table below (Table~\ref
 \end{table}
 
 %%%%%%%%%%%%%%
+\newpage
 \appendix
 
 \comment{STUFF WE MAYBE DON'T WANT: moved here from above:}
 
 \comment{Remove ILS thing and just add a paragraph citing Rodrigues et al and saying why this would be faster and would split the memory requirements across a bunch of processes.}
 
-\subsection*{Recapitation}
+\section{Recapitation}
 
 
 Doing this is as simple as:
@@ -798,7 +799,7 @@ you must set migration rates or else coalescence will never happen.
 (TODO: mention about how to recapitate with a nonuniform map, as in the docs?)
 
 
-\subsection*{Simplification}
+\section{Simplification}
 
 
 Probably, your simulations have produced many more fictitious genomes
@@ -872,7 +873,7 @@ parents and children can be both alive at the same time in the final generation.
 
 
 
-\subsection*{Adding neutral mutations to a SLiM simulation}
+\section{Adding neutral mutations to a SLiM simulation}
 
 % ```{figure} _static/pedigree_mutate.png
 


### PR DESCRIPTION
After discussing with @mufernando we decided to cut this quite a bit, so that
1. it just assigns fixed selection coefficients instead of randomly generating (so it doesn't have to keep track of the ID->s mapping)
2. it doesn't do any downstream analysis

However, I've also added a bit on VCF output (generating nucleotides, etc), and done some explaining about the SLiM mutation model (unfortunately necessary).